### PR TITLE
add asf file to enable the website also after the 1.7.2021

### DIFF
--- a/.asf.yml
+++ b/.asf.yml
@@ -1,0 +1,3 @@
+publish:
+  whoami: asf-site
+


### PR DESCRIPTION
As described in the EMail from Daniel, we need the asf.yml file to be sure that the mesos website will be online after the 1.7.

---
Dear Apache projects,
In order to simplify our web site publishing services and improve
self-serve for projects and stability of deployments, we will be turning
off the old 'gitwcsub' method of publishing git web sites. As of this
moment, this involves 120 web sites. All web sites should switch to our
self-serve method of publishing via the .asf.yaml meta-file. We aim to
turn off gitwcsub around July 1st.